### PR TITLE
split は PHP7 で廃止されたため、 explode に修正

### DIFF
--- a/src/Eccube2/Util/Install.php
+++ b/src/Eccube2/Util/Install.php
@@ -148,7 +148,7 @@ class Install
         /** @var \MDB2_Driver_Common $objDB */
         $objDB = $objQuery->conn;
 
-        $sql_split = split(';', $sql);
+        $sql_split = explode(';', $sql);
         foreach ($sql_split as $key => $val) {
             if (trim($val) === '') {
                 continue;


### PR DESCRIPTION
see https://www.php.net/manual/ja/function.split.php