### PR TITLE
既存のシーケンスが存在する場合エラーになってしまうのを修正

### DIFF
--- a/src/Eccube2/Util/Install.php
+++ b/src/Eccube2/Util/Install.php
@@ -169,14 +169,17 @@ class Install
         /** @var \MDB2_Driver_Manager_Common $objManager */
         $objManager = $objDB->loadModule('Manager');
 
+        $exists = $objManager->listSequences();
         foreach ($this->sequences as $seq) {
             $max = $objQuery->max($seq[1], $seq[0]);
 
             $seq_name = $seq[0] . '_' . $seq[1];
-            $result = $objManager->createSequence($seq_name, $max + 1);
+            if (!in_array($seq_name, $exists)) {
+                $result = $objManager->createSequence($seq_name, $max + 1);
 
-            if (\PEAR::isError($result)) {
-                throw new \Exception($result->message);
+                if (\PEAR::isError($result)) {
+                    throw new \Exception($result->message);
+                }
             }
         }
     }


### PR DESCRIPTION
既存のシーケンスが存在すると、エラーで止まってしまう
```
シーケンス作成
--------------

 シーケンスを作成しますか？ (yes/no) [yes]:
 > yes



  [Exception]
  MDB2 Error: already exists


install [-y|--yes] [--no-send-info] [--] [<shop_name>] [<admin_mail>]
```
存在する場合は、スキップするよう修正