### PR TITLE
EC-CUBE 2.17 プロジェクト内で利用可能にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ EC-CUBE2 を CLI で管理できるようになります。
 $ composer require ec-cube2/cli
 ```
 
-### EC-CUBE 2.17 内へのインストール方法
+EC-CUBE 2.17.x プロジェクトにインストールできない場合は次を試してみてください：
 
 ```
-# 1. PHP バージョン要件 (config.platform.php) を {"php": "5.5.9"} にします。
+# PHP バージョン要件 (config.platform.php) を {"php": "5.5.9"} にする。
 $ vi composer.json
 
-# 2. Symfonyコンポーネントの依存関係が衝突するので、 codeception は除去する必要があります。
+# codeception を除去する。
 $ composer remove codeception/codeception
 
-# 3. インストールします。
+# symfony/yaml を更新しつつインストールする。
 $ composer require ec-cube2/cli symfony/yaml --update-with-all-dependencies
 ```
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,26 @@
 EC-CUBE2 を CLI で管理できるようになります。  
 
 
-## Installation / Usage
+## Installation
 
 ```
-$ composer install ec-cube2/cli
+$ composer require ec-cube2/cli
 ```
+
+### EC-CUBE 2.17 内へのインストール方法
+
+```
+# 1. PHP バージョン要件 (config.platform.php) を {"php": "5.5.9"} にします。
+$ vi composer.json
+
+# 2. Symfonyコンポーネントの依存関係が衝突するので、 codeception は除去する必要があります。
+$ composer remove codeception/codeception
+
+# 3. インストールします。
+$ composer require ec-cube2/cli symfony/yaml --update-with-all-dependencies
+```
+
+## Usage
 
 ```
 $ ./vendor/bin/eccube

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
     "require": {
         "php": ">=5.3.3",
         "ext-mbstring": "*",
-        "symfony/config": "^3.4|^4.0",
-        "symfony/console": "^3.4|^4.0",
-        "symfony/event-dispatcher": "^3.4|^4.0",
-        "symfony/dependency-injection": "^3.4|^4.0"
+        "symfony/config": "^3.4",
+        "symfony/console": "^3.4",
+        "symfony/event-dispatcher": "^3.4",
+        "symfony/dependency-injection": "^3.4"
     },
     "require-dev": {
         "composer/composer": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
     "require": {
         "php": ">=5.3.3",
         "ext-mbstring": "*",
-        "symfony/config": "^3.4",
-        "symfony/console": "^3.4",
-        "symfony/event-dispatcher": "^3.4",
-        "symfony/dependency-injection": "^3.4"
+        "symfony/config": "^3.4|^4.4",
+        "symfony/console": "^3.4|^4.4",
+        "symfony/event-dispatcher": "^3.4|^4.4",
+        "symfony/dependency-injection": "^3.4|^4.4"
     },
     "require-dev": {
         "composer/composer": "^1.0",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -7,3 +7,6 @@ services:
         resource: '../src/Eccube2/Command/*'
         tags:
             - { name: 'console.command' }
+
+    Symfony\Component\EventDispatcher\EventDispatcherInterface:
+        alias: 'event_dispatcher'


### PR DESCRIPTION
#5 の件、動かせました。

## 問題

- EC-CUBE 2.17 の最新のプロジェクト内にインストールできない。
  - composer.json に手を加えるいくつかの手順が必要。
  - パッケージ更新をした結果、 Symfony コンポーネントのバージョンが4.4だと、 #5 の通り `... references interface "Symfony\Component\EventDispatcher\EventDispatcherInterface" but no such service exists` エラーが出る。
- README に `composer install` とあるが正しくは `composer require` 

## 修正

- README を改訂。
- Symfony コンポーネントの依存バージョンを3.xに限定。

## 最新のEC-CUBE2.17を用いた確認方法

```
git clone --depth=1 https://github.com/EC-CUBE/ec-cube2.git

cd ec-cube2

cat composer.json \
    | jj -v 5.5.9 config.platform.php \
    | jj -r -v '[{"type": "vcs", "url": "https://github.com/kaorukobo/eccube2-cli.git"}]' repositories \
    > composer.json.new
mv -f composer.json.new composer.json

composer remove codeception/codeception

composer require ec-cube2/cli:dev-work-with-eccube217 symfony/yaml --update-with-all-dependencies

./data/vendor/bin/eccube
```
