### PR TITLE
Symfony2.8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
     "require": {
         "php": ">=5.3.3",
         "ext-mbstring": "*",
-        "symfony/config": "^3.4|^4.4",
-        "symfony/console": "^3.4|^4.4",
-        "symfony/event-dispatcher": "^3.4|^4.4",
-        "symfony/dependency-injection": "^3.4|^4.4"
+        "symfony/config": "^2.8|^3.4|^4.4",
+        "symfony/console": "^2.8|^3.4|^4.4",
+        "symfony/event-dispatcher": "^2.8|^3.4|^4.4",
+        "symfony/dependency-injection": "^2.8|^3.4|^4.4"
     },
     "require-dev": {
         "composer/composer": "^1.0",


### PR DESCRIPTION
Symfony2.8 の依存関係を追加
config.platform 5.4.16 の環境(2.17.x)で以下のようなエラーになってしまい、**require php: >=5.3.3** と矛盾するため

```
  Problem 1
    - symfony/config[v3.4.0, ..., v3.4.47] require php ^5.5.9|>=7.0.8 -> your php version (5.4.16; overridden via config.platform, actual: 7.4.19) does not satisfy that requirement.
    - symfony/config[v4.4.0, ..., v4.4.8] require php ^7.1.3 -> your php version (5.4.16; overridden via config.platform, actual: 7.4.19) does not satisfy that requirement.
    - symfony/config[v4.4.9, ..., v4.4.33] require php >=7.1.3 -> your php version (5.4.16; overridden via config.platform, actual: 7.4.19) does not satisfy that requirement.
    - ec-cube2/cli dev-master requires symfony/config ^3.4|^4.4 -> satisfiable by symfony/config[v3.4.0, ..., v3.4.47, v4.4.0, ..., v4.4.33].
    - Root composer.json requires ec-cube2/cli dev-master@dev -> satisfiable by ec-cube2/cli[dev-master].
```